### PR TITLE
seems like exports.t is used now in (at least) jade 0.5.14

### DIFF
--- a/lib/jadevu.js
+++ b/lib/jadevu.js
@@ -1,4 +1,3 @@
-
 /**
  * Module exports
  */
@@ -34,6 +33,7 @@ var cs = ''
   +         'var r = _[i](p);'
   +         'return "undefined" != typeof jQuery ? jQuery(r) : r;'
   +       '}'
+  +     ', exports = {t: t}'
   +     ', _ = t._ = {};'
   +   't.noConflict = function(){'
   +     'w.template = p;'


### PR DESCRIPTION
somewhere in compiled, I get:

```
buf.push(key + '="' + exports.t.$e(val.join(' ')) + '"');
```
