### PR TITLE
Stringify the compiled output

### DIFF
--- a/lib/jadevu.js
+++ b/lib/jadevu.js
@@ -166,7 +166,7 @@ function compile (compiler, ast, opts) {
   return ''
     + 'function (locals) {'
     +   'var buf = [], t = window.template, attrs = t.$a, escape = t.$e;'
-    +   'with (locals || {}) {' + compiled + '};'
+    +   'with (locals || {}) {' + stringify(compiled) + '};'
     +   'return buf.join("");'
     + '}';
 }


### PR DESCRIPTION
Just calls stringify on the compiled jade so the output doesn't take so many lines when rendered.
