### PR TITLE
Support for option.self

### DIFF
--- a/lib/jadevu.js
+++ b/lib/jadevu.js
@@ -165,8 +165,8 @@ function compile (compiler, ast, opts) {
 
   return ''
     + 'function (locals) {'
-    +   'var buf = [], t = window.template, attrs = t.$a, escape = t.$e;'
-    +   'with (locals || {}) {' + compiled + '};'
+    +   'var buf = [], t = window.template, attrs = t.$a, escape = t.$e' + (opts.self ? ', self = locals || {};' : ';')
+    +   (opts.self ? compiled : 'with (locals || {}) {' + compiled + '}')
     +   'return buf.join("");'
     + '}';
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   , "version": "0.0.9"
   , "author": "Guillermo Rauch <guillermo@learnboost.com>"
   , "devDependencies": {
-        "jade": "0.16.1"
-      , "should": "0.2.1"
+        "jade": "0.20.x"
+      , "should": "0.4.x"
     }
 }

--- a/test.js
+++ b/test.js
@@ -45,7 +45,7 @@ var thrown = false;
 try {
   render('noid');
 } catch (e) {
-  e.message.should.include.string('`id`');
+  e.message.should.include('`id`');
   thrown = true;
 }
 
@@ -53,16 +53,16 @@ thrown.should.be.true;
 
 console.log('Testing that compiling a template includes the wrapper');
 
-render('wrapper').should.include.string('template');
-render('wrapper').should.include.string('template._');;
-render('wrapper').should.include.string('noConflict');
-render('wrapper').should.include.string('<script>');
+render('wrapper').should.include('template');
+render('wrapper').should.include('template._');;
+render('wrapper').should.include('noConflict');
+render('wrapper').should.include('<script>');
 
 console.log('Testing that the wrapper appears only once');
 
-render('twice').should.include.string('<span>Hello world</span>');
-render('twice').should.include.string('uno');
-render('twice').should.include.string('dos');
+render('twice').should.include('<span>Hello world</span>');
+render('twice').should.include('uno');
+render('twice').should.include('dos');
 render('twice').indexOf('.noConflict').should.equal(
   render('twice').lastIndexOf('.noConflict')
 );
@@ -85,6 +85,6 @@ template('woot').should.equal('<div>woot\n<p>woot\n</p></div>');
 
 console.log('Testing that templates dont include debug code');
 
-render('twice').should.not.include.string('.lineno');
+render('twice').should.not.include('.lineno');
 
 console.log('+ All tests passed');

--- a/test.js
+++ b/test.js
@@ -87,4 +87,13 @@ console.log('Testing that templates dont include debug code');
 
 render('twice').should.not.include('.lineno');
 
+console.log('Testing support for option.self');
+
+var rendered = render('self', { self: true });
+
+rendered.should.not.include('with (locals || {})');
+
+var template = execute(rendered);
+template('nowith', { foo: 'Abc' }).should.equal('<p>Abc</p>');
+
 console.log('+ All tests passed');

--- a/test/self.jade
+++ b/test/self.jade
@@ -1,0 +1,2 @@
+template(id="nowith"):
+  p= self.foo


### PR DESCRIPTION
Changed the compile function in Jadevu to support `option.self`.

If self is true, a local variable self is added to the template function and the compiled jade code is not wrapped in a `with` statement.

Also added tests for the use of self:true.

I had to up the dependency versions to get the tests to run...
