### PR TITLE
Fixes jadevu with recent versions of Jade.

### DIFF
--- a/lib/jadevu.js
+++ b/lib/jadevu.js
@@ -51,7 +51,7 @@ var cs = ''
   +   't.$e = ' + stringify(runtime.escape) + ';'
   +   't.$a = ' 
         + stringify(runtime.attrs)
-          .replace(/exports\.escape/g, 't.$e')
+          .replace(/exports\.escape/g, 'exports.t.$e')
           .replace(/Object\.keys/g, '$k')
           .replace(/Array\.isArray/g, '$a')
         + ';'


### PR DESCRIPTION
Jade added a second param 'escaped' for runtime.attrs. The regex broke in this case. The regex could probably be more elegant but it tries to be explicit to avoid this type of breakage in the future.
