### PR TITLE
Remove single parent element restriction 

### DIFF
--- a/lib/jadevu.js
+++ b/lib/jadevu.js
@@ -2,8 +2,6 @@
  * Module exports
  */
 
-module.exports = exports = Jadevu;
-
 /**
  * Version.
  */
@@ -78,75 +76,23 @@ jade.filters.template = function (block, compiler, params) {
     compiler.__templates = 0;
   }
 
-  return new Jadevu(
-      block
-    , compiler
-    , params || {}
-    , compiler.__templates++ == 0
-  ).compile();
-};
-
-/**
- * Compiler constructor.
- *
- * @api public
- */
-
-function Jadevu (block, compiler, params, includeScript) {
-  Compiler.call(this, block, compiler.options);
-
-  if (this.node.nodes.length > 2) {
-    throw new Error('Templates must be composed of a single parent element.');
-  }
-
-  this.compiler = compiler;
-  this.includeScript = includeScript;
-  this.id = params.id;
-
-  if (!this.id) {
+  if (!params || !params.id) {
     throw new Error('The first element of the `template:` filter must be the `id` tag');
   }
-}
 
-/**
- * Inherit from Compiler
- */
+  var compiled = 'window.template._[' + params.id + '] = ' + compile(
+      compiler.constructor
+    , block
+    , compiler.options
+  ) + ';';
 
-Jadevu.prototype.__proto__ = Compiler.prototype;
+  if (compiler.__templates++ === 0)
+    compiled = cs + compiled;
 
-/**
- * Captures the tag we use as identifier of the template (`id`)
- *
- * @api public
- */
-
-Jadevu.prototype.visitTag = function (node) {
-  if (!this.id) {
-    if ('id' != node.name) {
-      throw new Error('The first element of the `template:` filter must be the `id` tag');
-
-    }
-
-    this.id = node.text.nodes[0].trim();
-  } else {
-    var script = new Tag('script')
-      , text = '';
-
-    if (this.includeScript) {
-      text += cs;
-    }
-
-    text += 'window.template._[' + this.id + '] = ' + compile(
-        this.compiler.constructor
-      , node
-      , this.compiler.options
-    ) + ';';
-
-    script.code = new Code(JSON.stringify(text), true, false);
-
-    Compiler.prototype.visitTag.call(this, script);
-  }
-}
+  return "buf.push('<script>');buf.push("
+    + JSON.stringify(compiled)
+    + ");buf.push('</script>')";
+};
 
 /**
  * Compiles a function from Nodes.

--- a/lib/jadevu.js
+++ b/lib/jadevu.js
@@ -14,8 +14,6 @@ exports.version = '0.0.9';
 
 var jade = require('jade')
   , runtime = jade.runtime
-  , Tag = jade.nodes.Tag
-  , Code = jade.nodes.Code
   , Compiler = jade.Compiler
 
 /**

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   , "author": "Guillermo Rauch <guillermo@learnboost.com>"
   , "devDependencies": {
         "jade": "0.16.1"
-      , "should": "0.2.1"
+      , "should": "1.1.1"
     }
 }

--- a/test.js
+++ b/test.js
@@ -45,7 +45,7 @@ var thrown = false;
 try {
   render('noid');
 } catch (e) {
-  e.message.should.include.string('`id`');
+  e.message.should.include('`id`');
   thrown = true;
 }
 
@@ -53,16 +53,16 @@ thrown.should.be.true;
 
 console.log('Testing that compiling a template includes the wrapper');
 
-render('wrapper').should.include.string('template');
-render('wrapper').should.include.string('template._');;
-render('wrapper').should.include.string('noConflict');
-render('wrapper').should.include.string('<script>');
+render('wrapper').should.include('template');
+render('wrapper').should.include('template._');;
+render('wrapper').should.include('noConflict');
+render('wrapper').should.include('<script>');
 
 console.log('Testing that the wrapper appears only once');
 
-render('twice').should.include.string('<span>Hello world</span>');
-render('twice').should.include.string('uno');
-render('twice').should.include.string('dos');
+render('twice').should.include('<span>Hello world</span>');
+render('twice').should.include('uno');
+render('twice').should.include('dos');
 render('twice').indexOf('.noConflict').should.equal(
   render('twice').lastIndexOf('.noConflict')
 );
@@ -85,6 +85,6 @@ template('woot').should.equal('<div>woot\n<p>woot\n</p></div>');
 
 console.log('Testing that templates dont include debug code');
 
-render('twice').should.not.include.string('.lineno');
+render('twice').should.not.include('.lineno');
 
 console.log('+ All tests passed');

--- a/test.js
+++ b/test.js
@@ -87,4 +87,10 @@ console.log('Testing that templates dont include debug code');
 
 render('twice').should.not.include('.lineno');
 
+console.log('Testing that many nodes are ok');
+
+var template = execute(render('many-nodes'));
+
+template('many-nodes', { three: 3 }).should.equal('<tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr>');
+
 console.log('+ All tests passed');

--- a/test/many-nodes.jade
+++ b/test/many-nodes.jade
@@ -1,0 +1,4 @@
+template(id="many-nodes"):
+  tr: td 1
+  tr: td 2
+  tr: td= three


### PR DESCRIPTION
you can now do:

```
template(id="hot-stuff"):
  li 1
  li 2
  li 3
```

and be all ok.

I ended up not extending jade's Compiler anymore and simply call it instead. I could use feedback on the amount of elimination I ended up doing. all tests still pass.
